### PR TITLE
mimc1 commitment model uses 32 byte values for hashing

### DIFF
--- a/models/tests/proof_test.go
+++ b/models/tests/proof_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/iotaledger/trie.go/models/trie_kzg_bn256"
 	"github.com/iotaledger/trie.go/models/trie_mimc"
 	"github.com/iotaledger/trie.go/models/trie_mimc/trie_mimc_verify"
+	"github.com/iotaledger/trie.go/models/trie_mimc1"
+	"github.com/iotaledger/trie.go/models/trie_mimc1/trie_mimc1_verify"
 	"github.com/iotaledger/trie.go/trie"
 	"github.com/stretchr/testify/require"
 )
@@ -176,8 +178,6 @@ func TestTrieProofMimc(t *testing.T) {
 			err := trie_mimc_verify.Validate(proof, rootC.Bytes())
 			require.NoError(t, err)
 
-			// t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
-
 			key, term := trie_mimc_verify.MustKeyWithTerminal(proof)
 			c := model.CommitToData([]byte("1"))
 			c1 := model.CommitToData(term)
@@ -221,8 +221,14 @@ func TestTrieProofMimc(t *testing.T) {
 			require.True(t, model.EqualCommitments(c, c1))
 		})
 	}
-	runTest32 := func(arity trie.PathArity) {
-		model := trie_mimc.New(arity, trie_mimc.HashSize256)
+	runTest(trie.PathArity256)
+	runTest(trie.PathArity16)
+	runTest(trie.PathArity2)
+}
+
+func TestTrieProofMimc1(t *testing.T) {
+	runTest := func(arity trie.PathArity) {
+		model := trie_mimc1.New(arity)
 		t.Run("proof empty trie"+tn(model), func(t *testing.T) {
 			store := trie.NewInMemoryKVStore()
 			tr := trie.New(model, store, nil)
@@ -231,7 +237,7 @@ func TestTrieProofMimc(t *testing.T) {
 			proof := model.Proof(nil, tr)
 			require.EqualValues(t, 0, len(proof.Path))
 		})
-		t.Run("proof one entry 1"+" "+arity.String(), func(t *testing.T) {
+		t.Run("proof one entry 1"+tn(model), func(t *testing.T) {
 			store := trie.NewInMemoryKVStore()
 			tr := trie.New(model, store, nil)
 
@@ -242,24 +248,24 @@ func TestTrieProofMimc(t *testing.T) {
 			require.EqualValues(t, 1, len(proof.Path))
 
 			rootC := trie.RootCommitment(tr)
-			err := trie_mimc_verify.Validate(proof, rootC.Bytes())
+			err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
 			require.NoError(t, err)
 
-			//t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
+			// t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
 
-			key, term := trie_mimc_verify.MustKeyWithTerminal(proof)
-			c := model.CommitToData([]byte("1"))
-			c1 := model.CommitToData(term)
+			key, term := trie_mimc1_verify.MustKeyWithTerminal(proof)
+			c := trie_mimc1.CommitToDataRaw([]byte("1"))
 			require.EqualValues(t, 0, len(key))
-			require.True(t, model.EqualCommitments(c1, c))
+			require.EqualValues(t, term, trie_mimc1.HashData(c))
 
-			proof = model.Proof([]byte("a"), tr)
+			unpackedKey := trie.UnpackBytes([]byte("a"), arity)
+			proof = model.Proof(unpackedKey, tr)
 			require.EqualValues(t, 1, len(proof.Path))
 
 			rootC = trie.RootCommitment(tr)
-			err = trie_mimc_verify.Validate(proof, rootC.Bytes())
+			err = trie_mimc1_verify.Validate(proof, rootC.Bytes())
 			require.NoError(t, err)
-			require.True(t, trie_mimc_verify.IsProofOfAbsence(proof))
+			require.True(t, trie_mimc1_verify.IsProofOfAbsence(proof))
 			t.Logf("proof absence size = %d bytes", trie.MustSize(proof))
 		})
 		t.Run("proof one entry 2"+tn(model), func(t *testing.T) {
@@ -272,21 +278,25 @@ func TestTrieProofMimc(t *testing.T) {
 			require.EqualValues(t, 1, len(proof.Path))
 
 			rootC := trie.RootCommitment(tr)
-			err := trie_mimc_verify.Validate(proof, rootC.Bytes())
+			err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
 			require.NoError(t, err)
-			require.True(t, trie_mimc_verify.IsProofOfAbsence(proof))
+			require.True(t, trie_mimc1_verify.IsProofOfAbsence(proof))
 
 			proof = model.Proof([]byte("1"), tr)
 			require.EqualValues(t, 1, len(proof.Path))
 
-			err = trie_mimc_verify.ValidateWithValue(proof, rootC.Bytes(), []byte("2"))
+			err = trie_mimc1_verify.Validate(proof, rootC.Bytes())
 			require.NoError(t, err)
+			require.False(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+
+			_, term := trie_mimc1_verify.MustKeyWithTerminal(proof)
+			c := trie_mimc1.CommitToDataRaw([]byte("2"))
+			require.EqualValues(t, term, trie_mimc1.HashData(c))
 		})
 	}
 	runTest(trie.PathArity256)
 	runTest(trie.PathArity16)
 	runTest(trie.PathArity2)
-	runTest32(trie.PathArity256)
 }
 
 func TestTrieProofWithDeletesBlake2b32(t *testing.T) {
@@ -771,6 +781,179 @@ func TestTrieProofWithDeletesMimc(t *testing.T) {
 				err := trie_mimc_verify.Validate(proof, rootC.Bytes())
 				require.NoError(t, err)
 				require.True(t, trie_mimc_verify.IsProofOfAbsence(proof))
+				//t.Logf("key: '%s', proof absence len: %d", s, len(proof.Path))
+				//t.Logf("proof absence size = %d bytes", trie_go.MustSize(proof))
+			}
+			for i := 0; i < 5000; i++ {
+				if i < 10 {
+					t.Logf("len[%d] = %d", i, lenStats[i])
+				}
+				if size100Stats[i] != 0 {
+					t.Logf("size[%d] = %d", i*100, size100Stats[i])
+				}
+			}
+		})
+		t.Run("reconcile"+" "+arity.String(), func(t *testing.T) {
+			data = genRnd4()
+			data = data[:1000]
+			t.Logf("data len = %d", len(data))
+			store := trie.NewInMemoryKVStore()
+			for _, s := range data {
+				store.Set([]byte("1"+s), []byte(s+"2"))
+			}
+			trieStore := trie.NewInMemoryKVStore()
+			tr1 = trie.New(model, trieStore, nil)
+			store.Iterate(func(k, v []byte) bool {
+				tr1.Update([]byte(k), v)
+				return true
+			})
+			tr1.Commit()
+			diff := tr1.Reconcile(store)
+			require.EqualValues(t, 0, len(diff))
+		})
+	}
+	runTest(trie.PathArity256)
+	runTest(trie.PathArity16)
+	runTest(trie.PathArity2)
+}
+
+func TestTrieProofWithDeletesMimc1(t *testing.T) {
+	var tr1 *trie.Trie
+	var rootC trie.VCommitment
+	var model *trie_mimc1.CommitmentModel
+
+	initTrie := func(dataAdd []string, arity trie.PathArity) {
+		model = trie_mimc1.New(arity)
+		store := trie.NewInMemoryKVStore()
+		tr1 = trie.New(model, store, nil)
+		for _, s := range dataAdd {
+			tr1.Update([]byte(s), []byte(s+"++"))
+		}
+	}
+	deleteKeys := func(keysDelete []string) {
+		for _, s := range keysDelete {
+			tr1.Update([]byte(s), nil)
+		}
+	}
+	commitTrie := func() trie.VCommitment {
+		tr1.Commit()
+		return trie.RootCommitment(tr1)
+	}
+	data := []string{"a", "ab", "ac", "abc", "abd", "ad", "ada", "adb", "adc", "c", "ad+dddgsssisd"}
+	runTest := func(arity trie.PathArity) {
+		t.Run("proof many entries 1"+"-"+arity.String(), func(t *testing.T) {
+			initTrie(data, arity)
+			rootC = commitTrie()
+			for _, s := range data {
+				proof := model.Proof([]byte(s), tr1)
+				require.False(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				//t.Logf("key: '%s', proof len: %d", s, len(proof.Path))
+				//t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
+			}
+		})
+		t.Run("proof many entries 2"+" "+arity.String(), func(t *testing.T) {
+			delKeys := []string{"1", "2", "3", "12345", "ab+", "ada+"}
+			initTrie(data, arity)
+			deleteKeys(delKeys)
+			rootC = commitTrie()
+
+			for _, s := range data {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.False(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				//t.Logf("key: '%s', proof presence lenPlus1: %d", s, len(proof.Path))
+				//t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
+			}
+			for _, s := range delKeys {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.True(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				//t.Logf("key: '%s', proof absence lenPlus1: %d", s, len(proof.Path))
+				//t.Logf("proof absence size = %d bytes", trie_go.MustSize(proof))
+			}
+		})
+		t.Run("proof many entries 3"+" "+arity.String(), func(t *testing.T) {
+			delKeys := []string{"1", "2", "3", "12345", "ab+", "ada+"}
+			allData := make([]string, 0, len(data)+len(delKeys))
+			allData = append(allData, data...)
+			allData = append(allData, delKeys...)
+			initTrie(allData, arity)
+			deleteKeys(delKeys)
+			rootC = commitTrie()
+
+			for _, s := range data {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.False(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				//t.Logf("key: '%s', proof presence lenPlus1: %d", s, len(proof.Path))
+				sz := trie.MustSize(proof)
+				//t.Logf("proof presence size = %d bytes", sz)
+
+				proofBin := proof.Bytes()
+				require.EqualValues(t, len(proofBin), sz)
+				proofBack, err := trie_mimc1.ProofFromBytes(proofBin)
+				require.NoError(t, err)
+				err = trie_mimc1_verify.Validate(proofBack, rootC.Bytes())
+				require.NoError(t, err)
+				require.True(t, bytes.Equal(proof.Key, proofBack.Key))
+				require.False(t, trie_mimc1_verify.IsProofOfAbsence(proofBack))
+			}
+			for _, s := range delKeys {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.True(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				t.Logf("key: '%s', proof absence lenPlus1: %d", s, len(proof.Path))
+				sz := trie.MustSize(proof)
+				t.Logf("proof absence size = %d bytes", sz)
+
+				proofBin := proof.Bytes()
+				require.EqualValues(t, len(proofBin), sz)
+				proofBack, err := trie_mimc1.ProofFromBytes(proofBin)
+				require.NoError(t, err)
+				err = trie_mimc1_verify.Validate(proofBack, rootC.Bytes())
+				require.NoError(t, err)
+				require.True(t, bytes.Equal(proof.Key, proofBack.Key))
+				require.True(t, trie_mimc1_verify.IsProofOfAbsence(proofBack))
+			}
+		})
+		t.Run("proof many entries rnd"+" "+arity.String(), func(t *testing.T) {
+			addKeys, delKeys := gen2different(100)
+			t.Logf("lenPlus1 adds: %d, lenPlus1 dels: %d", len(addKeys), len(delKeys))
+			allData := make([]string, 0, len(addKeys)+len(delKeys))
+			allData = append(allData, addKeys...)
+			allData = append(allData, delKeys...)
+			initTrie(allData, arity)
+			deleteKeys(delKeys)
+			rootC = commitTrie()
+
+			lenStats := make(map[int]int)
+			size100Stats := make(map[int]int)
+			for _, s := range addKeys {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.False(t, trie_mimc1_verify.IsProofOfAbsence(proof))
+				lenP := len(proof.Path)
+				sizeP100 := trie.MustSize(proof) / 100
+				//t.Logf("key: '%s', proof presence lenPlus1: %d", s, )
+				//t.Logf("proof presence size = %d bytes", trie_go.MustSize(proof))
+
+				l := lenStats[lenP]
+				lenStats[lenP] = l + 1
+				sz := size100Stats[sizeP100]
+				size100Stats[sizeP100] = sz + 1
+			}
+			for _, s := range delKeys {
+				proof := model.Proof([]byte(s), tr1)
+				err := trie_mimc1_verify.Validate(proof, rootC.Bytes())
+				require.NoError(t, err)
+				require.True(t, trie_mimc1_verify.IsProofOfAbsence(proof))
 				//t.Logf("key: '%s', proof absence len: %d", s, len(proof.Path))
 				//t.Logf("proof absence size = %d bytes", trie_go.MustSize(proof))
 			}

--- a/models/tests/trie_go_test.go
+++ b/models/tests/trie_go_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/trie.go/models/trie_blake2b"
 	"github.com/iotaledger/trie.go/models/trie_kzg_bn256"
 	"github.com/iotaledger/trie.go/models/trie_mimc"
+	"github.com/iotaledger/trie.go/models/trie_mimc1"
 	"github.com/iotaledger/trie.go/trie"
 	"github.com/stretchr/testify/require"
 )
@@ -107,12 +108,15 @@ func TestNode(t *testing.T) {
 	runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize256))
 	runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize160))
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity256))
 	runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize256))
 	runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize160))
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity16))
 	runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize256))
 	runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize160))
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity2))
 
 	runTest(t, trie_kzg_bn256.New())
 }
@@ -493,6 +497,9 @@ func TestTrieBase(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity256))
+	runTest(t, trie_mimc1.New(trie.PathArity16))
+	runTest(t, trie_mimc1.New(trie.PathArity2))
 
 	runTest(t, trie_kzg_bn256.New())
 }
@@ -726,6 +733,9 @@ func TestTrieRnd(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity16), true)
+	runTest(t, trie_mimc1.New(trie.PathArity2), true)
 
 	runTest(t, trie_kzg_bn256.New(), true)
 }
@@ -895,6 +905,9 @@ func TestTrieRndKeyCommitment(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity16), true)
+	runTest(t, trie_mimc1.New(trie.PathArity2), true)
 
 	runTest(t, trie_kzg_bn256.New(), true)
 }
@@ -1041,6 +1054,9 @@ func TestTrieWithDeletion(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity256))
+	runTest(t, trie_mimc1.New(trie.PathArity16))
+	runTest(t, trie_mimc1.New(trie.PathArity2))
 
 	runTest(t, trie_kzg_bn256.New())
 }
@@ -1140,6 +1156,9 @@ func TestTrieWithDeletionDeterm(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256), true)
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity256), true)
+	runTest(t, trie_mimc1.New(trie.PathArity16), true)
+	runTest(t, trie_mimc1.New(trie.PathArity2), true)
 
 	runTest(t, trie_kzg_bn256.New(), true)
 }
@@ -1195,6 +1214,9 @@ func TestDeleteCommit(t *testing.T) {
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity256))
+	runTest(t, trie_mimc1.New(trie.PathArity16))
+	runTest(t, trie_mimc1.New(trie.PathArity2))
 
 	runTest(t, trie_kzg_bn256.New())
 }
@@ -1234,15 +1256,18 @@ func TestGenTrie(t *testing.T) {
 		})
 	}
 
-	//runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize256))
-	//runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize256))
-	//runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize256))
-	//runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize160))
-	//runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize160))
-	//runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize160))
+	runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize256))
+	runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize256))
+	runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize256))
+	runTest(t, trie_blake2b.New(trie.PathArity256, trie_blake2b.HashSize160))
+	runTest(t, trie_blake2b.New(trie.PathArity16, trie_blake2b.HashSize160))
+	runTest(t, trie_blake2b.New(trie.PathArity2, trie_blake2b.HashSize160))
 	runTest(t, trie_mimc.New(trie.PathArity256, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity16, trie_mimc.HashSize256))
 	runTest(t, trie_mimc.New(trie.PathArity2, trie_mimc.HashSize256))
+	runTest(t, trie_mimc1.New(trie.PathArity256))
+	runTest(t, trie_mimc1.New(trie.PathArity16))
+	runTest(t, trie_mimc1.New(trie.PathArity2))
 
 	runTest(t, trie_kzg_bn256.New())
 }

--- a/models/trie_mimc1/model.go
+++ b/models/trie_mimc1/model.go
@@ -1,0 +1,318 @@
+// Package trie_mimc implements trie.CommitmentModel based on mimc 32-byte hashing
+package trie_mimc1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
+	"github.com/iotaledger/trie.go/trie"
+)
+
+const HashSize = 32
+
+// terminalCommitment commits to the data of arbitrary size.
+// len(bytes) can't be > 32
+// if isHash == true, len(bytes) must be 32
+// otherwise it is not hashed value, mus be len(bytes) <= 32
+type terminalCommitment struct {
+	rawCommitment      []byte
+	isCostlyCommitment bool
+}
+
+// vectorCommitment is a MIMC hash of the vector elements
+type vectorCommitment [HashSize]byte
+
+// CommitmentModel provides commitment model implementation for the 256+ trie
+// valueSizeOptimizationThreshold means that for terminal commitments to values
+// longer than threshold, the terminal commitments will always be stored with the trie node,
+// i.e. ForceStoreTerminalWithNode will return true. For terminal commitments
+// of this or smaller size, the choice depends on the trie setup
+// Default valueSizeOptimizationThreshold = 0, which means that by default all
+// values are stored in the node.
+// If valueSizeOptimizationThreshold > 0 valueStore must be specified in the trie parameters
+// Reasonable value of valueSizeOptimizationThreshold, allows significantly optimize trie storage without
+// requiring hashing big data each time
+type CommitmentModel struct {
+	arity                          trie.PathArity
+	valueSizeOptimizationThreshold int
+}
+
+// New creates new CommitmentModel.
+func New(arity trie.PathArity, valueSizeOptimizationThreshold ...int) *CommitmentModel {
+	t := 0
+	if len(valueSizeOptimizationThreshold) > 0 {
+		t = valueSizeOptimizationThreshold[0]
+	}
+	return &CommitmentModel{
+		arity:                          arity,
+		valueSizeOptimizationThreshold: t,
+	}
+}
+
+func (m *CommitmentModel) PathArity() trie.PathArity {
+	return m.arity
+}
+
+func (m *CommitmentModel) EqualCommitments(c1, c2 trie.Serializable) bool {
+	return equalCommitments(c1, c2)
+}
+
+func equalCommitments(c1, c2 trie.Serializable) bool {
+	if equals, conclusive := trie.CheckNils(c1, c2); conclusive {
+		return equals
+	}
+	// both not nils
+	if t1, ok1 := c1.(*terminalCommitment); ok1 {
+		if t2, ok2 := c2.(*terminalCommitment); ok2 {
+			return bytes.Equal(t1.rawCommitment, t2.rawCommitment)
+		}
+	}
+	if v1, ok1 := c1.(*vectorCommitment); ok1 {
+		if v2, ok2 := c2.(*vectorCommitment); ok2 {
+			return *v1 == *v2
+		}
+	}
+	return false
+}
+
+// UpdateNodeCommitment computes update to the node data and, optionally, updates existing commitment
+// In MIMC implementation delta it just means computing the hash of data
+func (m *CommitmentModel) UpdateNodeCommitment(mutate *trie.NodeData, childUpdates map[byte]trie.VCommitment, _ bool, newTerminalUpdate trie.TCommitment, update *trie.VCommitment) {
+	deleted := make([]byte, 0, 256)
+	for i, upd := range childUpdates {
+		mutate.ChildCommitments[i] = upd
+		if upd == nil {
+			// if update == nil, it means child commitment must be removed
+			deleted = append(deleted, i)
+		}
+	}
+	for _, i := range deleted {
+		delete(mutate.ChildCommitments, i)
+	}
+	mutate.Terminal = newTerminalUpdate // for hash commitment just replace
+	if len(mutate.ChildCommitments) == 0 && mutate.Terminal == nil {
+		return
+	}
+	if update != nil {
+		ret := new(vectorCommitment)
+		copy((*ret)[:], HashTheVector(m.makeHashVector(mutate), m.arity))
+		*update = ret
+	}
+}
+
+// CalcNodeCommitment computes commitment of the node. It is suboptimal in KZG trie.
+// Used in computing root commitment
+func (m *CommitmentModel) CalcNodeCommitment(par *trie.NodeData) trie.VCommitment {
+	if len(par.ChildCommitments) == 0 && par.Terminal == nil {
+		return nil
+	}
+	ret := new(vectorCommitment)
+	copy((*ret)[:], HashTheVector(m.makeHashVector(par), m.arity))
+	return ret
+}
+
+func (m *CommitmentModel) CommitToData(data []byte) trie.TCommitment {
+	if len(data) == 0 {
+		// empty slice -> no data (deleted)
+		return nil
+	}
+	return &terminalCommitment{
+		rawCommitment:      CommitToDataRaw(data),
+		isCostlyCommitment: len(data) > m.valueSizeOptimizationThreshold,
+	}
+}
+
+func (m *CommitmentModel) Description() string {
+	return fmt.Sprintf("trie commitment model implementation based on MIMC (32 bytes), arity: %s, terminal optimization threshold: %d",
+		m.arity, m.valueSizeOptimizationThreshold)
+}
+
+func (m *CommitmentModel) ShortName() string {
+	return "mimc1_" + m.PathArity().String()
+}
+
+// NewTerminalCommitment creates empty terminal commitment
+func (m *CommitmentModel) NewTerminalCommitment() trie.TCommitment {
+	return newTerminalCommitment()
+}
+
+// NewVectorCommitment create empty vector commitment
+func (m *CommitmentModel) NewVectorCommitment() trie.VCommitment {
+	return new(vectorCommitment)
+}
+
+func (m *CommitmentModel) ForceStoreTerminalWithNode(c trie.TCommitment) bool {
+	return c.(*terminalCommitment).isCostlyCommitment
+}
+
+// CommitToDataRaw commits to data. It hashes it only if data size
+// exceeds 32 bytes, otherwise raw data is used
+func CommitToDataRaw(data []byte) []byte {
+	var ret []byte
+	if len(data) <= HashSize {
+		ret = make([]byte, len(data))
+		copy(ret, data)
+	} else {
+		ret = HashData(data)
+	}
+	return ret
+}
+
+// HashData is MIMC hashing
+func HashData(data []byte) []byte {
+	h := mimc.NewMiMC()
+	h.Write(data)
+	ret := h.Sum(nil)
+	if len(ret) != HashSize {
+		panic("internal inconsistency")
+	}
+	return ret
+}
+
+// makeHashVector makes the node vector to be hashed. Missing children are nil
+// For MIMC implementation we make each non-nil vector element 32 byte hash
+func (m *CommitmentModel) makeHashVector(nodeData *trie.NodeData) [][]byte {
+	hashes := make([][]byte, m.arity.VectorLength())
+	for i, c := range nodeData.ChildCommitments {
+		trie.Assert(int(i) < m.arity.VectorLength(), "int(i)<m.arity.VectorLength()")
+		hashes[i] = c.Bytes()
+	}
+	if nodeData.Terminal != nil {
+		hashes[m.arity.TerminalCommitmentIndex()] = HashData(nodeData.Terminal.(*terminalCommitment).rawCommitment)
+	}
+	hashes[m.arity.PathFragmentCommitmentIndex()] = HashData(nodeData.PathFragment)
+	return hashes
+}
+
+// HashTheVector concatenates all hashes and MIMC-hashes them
+// nil commitments are treated as 32 byte long all-0 values
+func HashTheVector(hashes [][]byte, arity trie.PathArity) []byte {
+	buf := make([]byte, arity.VectorLength()*HashSize)
+	for i, h := range hashes {
+		if h == nil {
+			continue
+		}
+		if len(h) != HashSize {
+			panic("HashTheVector: wrong parameter size")
+		}
+		pos := i * HashSize
+		copy(buf[pos:pos+HashSize], h)
+	}
+	return HashData(buf)
+}
+
+// *vectorCommitment implements trie_go.VCommitment
+var _ trie.VCommitment = &vectorCommitment{}
+
+func (v *vectorCommitment) Bytes() []byte {
+	return (*v)[:]
+}
+
+func (v *vectorCommitment) Read(r io.Reader) error {
+	n, err := r.Read((*v)[:])
+	if err != nil {
+		return err
+	}
+	if n != HashSize {
+		return errors.New("wrong data size")
+	}
+	return nil
+}
+
+func (v *vectorCommitment) Write(w io.Writer) error {
+	_, err := w.Write((*v)[:])
+	return err
+}
+
+func (v *vectorCommitment) String() string {
+	return hex.EncodeToString((*v)[:])
+}
+
+func (v *vectorCommitment) Clone() trie.VCommitment {
+	ret := new(vectorCommitment)
+	copy((*ret)[:], (*v)[:])
+	return ret
+}
+
+func (v *vectorCommitment) Update(delta trie.VCommitment) {
+	m, ok := delta.(*vectorCommitment)
+	if !ok {
+		panic("MIMC hash commitment expected")
+	}
+	*v = *m
+}
+
+// *terminalCommitment implements trie_go.TCommitment
+var _ trie.TCommitment = &terminalCommitment{}
+
+func newTerminalCommitment() *terminalCommitment {
+	// all 0 non hashed value
+	return &terminalCommitment{
+		rawCommitment:      make([]byte, 0, HashSize),
+		isCostlyCommitment: false,
+	}
+}
+
+const (
+	sizeMask             = uint8(0x3F)
+	costlyCommitmentMask = ^sizeMask
+)
+
+func (t *terminalCommitment) Write(w io.Writer) error {
+	trie.Assert(len(t.rawCommitment) <= 32, "len(t.bytes) <= 32")
+	l := byte(len(t.rawCommitment))
+	if t.isCostlyCommitment {
+		l |= costlyCommitmentMask
+	}
+	if err := trie.WriteByte(w, l); err != nil {
+		return err
+	}
+	_, err := w.Write(t.rawCommitment)
+	return err
+}
+
+func (t *terminalCommitment) Read(r io.Reader) error {
+	var err error
+	var l byte
+	if l, err = trie.ReadByte(r); err != nil {
+		return err
+	}
+	t.isCostlyCommitment = (l & costlyCommitmentMask) != 0
+	l &= sizeMask
+
+	if l > 32 {
+		return fmt.Errorf("wrong data size")
+	}
+	if l > 0 {
+		t.rawCommitment = make([]byte, l)
+
+		n, err := r.Read(t.rawCommitment)
+		if err != nil {
+			return err
+		}
+		if n != int(l) {
+			return errors.New("bad data length")
+		}
+	}
+	return nil
+}
+
+func (t *terminalCommitment) Bytes() []byte {
+	return trie.MustBytes(t)
+}
+
+func (t *terminalCommitment) String() string {
+	return hex.EncodeToString(t.rawCommitment[:])
+}
+
+func (t *terminalCommitment) Clone() trie.TCommitment {
+	if t == nil {
+		return nil
+	}
+	ret := *t
+	return &ret
+}

--- a/models/trie_mimc1/node_test.go
+++ b/models/trie_mimc1/node_test.go
@@ -1,0 +1,46 @@
+package trie_mimc1
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/iotaledger/trie.go/trie"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeSerialization(t *testing.T) {
+	runTest := func(arity trie.PathArity) {
+		model := New(arity)
+		t.Run(fmt.Sprintf("1: %s", arity), func(t *testing.T) {
+			n := trie.NewNodeData()
+			n.ChildCommitments[0] = model.NewVectorCommitment()
+			n.ChildCommitments[byte(arity)] = model.NewVectorCommitment()
+
+			var buf bytes.Buffer
+			key := []byte("abc")
+			err := n.Write(&buf, arity, false, false)
+			require.NoError(t, err)
+			nBack, err := trie.NodeDataFromBytes(model, buf.Bytes(), key, arity, nil)
+			require.NoError(t, err)
+
+			require.True(t, model.EqualCommitments(model.CalcNodeCommitment(n), model.CalcNodeCommitment(nBack)))
+		})
+		t.Run(fmt.Sprintf("2: %s", arity), func(t *testing.T) {
+			n := trie.NewNodeData()
+			n.Terminal = model.CommitToData([]byte("a"))
+
+			var buf bytes.Buffer
+			key := []byte("abc")
+			err := n.Write(&buf, arity, false, false)
+			require.NoError(t, err)
+			nBack, err := trie.NodeDataFromBytes(model, buf.Bytes(), key, arity, nil)
+			require.NoError(t, err)
+
+			require.True(t, model.EqualCommitments(model.CalcNodeCommitment(n), model.CalcNodeCommitment(nBack)))
+		})
+	}
+	runTest(trie.PathArity256)
+	runTest(trie.PathArity16)
+	runTest(trie.PathArity2)
+}

--- a/models/trie_mimc1/proof.go
+++ b/models/trie_mimc1/proof.go
@@ -1,0 +1,243 @@
+package trie_mimc1
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/iotaledger/trie.go/trie"
+)
+
+// Proof MIMC 32 byte model-specific proof of inclusion
+type Proof struct {
+	PathArity trie.PathArity
+	Key       []byte
+	Path      []*ProofElement
+}
+
+type ProofElement struct {
+	PathFragment []byte
+	Children     map[byte][]byte
+	Terminal     []byte
+	ChildIndex   int
+}
+
+func ProofFromBytes(data []byte) (*Proof, error) {
+	ret := &Proof{}
+	if err := ret.Read(bytes.NewReader(data)); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// Proof converts generic proof path to the Merkle proof path
+func (m *CommitmentModel) Proof(key []byte, tr trie.NodeStore) *Proof {
+	unpackedKey := trie.UnpackBytes(key, tr.PathArity())
+	proofGeneric := trie.GetProofGeneric(tr, unpackedKey)
+	if proofGeneric == nil {
+		return nil
+	}
+	ret := &Proof{
+		PathArity: tr.PathArity(),
+		Key:       proofGeneric.Key,
+		Path:      make([]*ProofElement, len(proofGeneric.Path)),
+	}
+	var elemKeyPosition int
+	var isLast bool
+	var childIndex int
+
+	for i, k := range proofGeneric.Path {
+		node, ok := tr.GetNode(k)
+		if !ok {
+			panic(fmt.Errorf("can't find node key '%x'", k))
+		}
+		isLast = i == len(proofGeneric.Path)-1
+		if !isLast {
+			elemKeyPosition += len(node.PathFragment())
+			childIndex = int(unpackedKey[elemKeyPosition])
+			elemKeyPosition++
+		} else {
+			switch proofGeneric.Ending {
+			case trie.EndingTerminal:
+				childIndex = m.arity.TerminalCommitmentIndex()
+			case trie.EndingExtend, trie.EndingSplit:
+				childIndex = m.arity.PathFragmentCommitmentIndex()
+			default:
+				panic("wrong ending code")
+			}
+		}
+		em := &ProofElement{
+			PathFragment: node.PathFragment(),
+			Children:     make(map[byte][]byte),
+			Terminal:     nil,
+			ChildIndex:   childIndex,
+		}
+		if node.Terminal() != nil {
+			em.Terminal = HashData(node.Terminal().(*terminalCommitment).rawCommitment)
+		}
+		for idx, v := range node.ChildCommitments() {
+			if int(idx) == childIndex {
+				// skipping the commitment which must come from the next child
+				continue
+			}
+			em.Children[idx] = v.Bytes()
+		}
+		ret.Path[i] = em
+	}
+	return ret
+}
+
+func (p *Proof) Bytes() []byte {
+	return trie.MustBytes(p)
+}
+
+func (p *Proof) Write(w io.Writer) error {
+	var err error
+	if err = trie.WriteByte(w, byte(p.PathArity)); err != nil {
+		return err
+	}
+	encodedKey, err := trie.EncodeUnpackedBytes(p.Key, p.PathArity)
+	if err != nil {
+		return err
+	}
+	if err = trie.WriteBytes16(w, encodedKey); err != nil {
+		return err
+	}
+	if err = trie.WriteUint16(w, uint16(len(p.Path))); err != nil {
+		return err
+	}
+	for _, e := range p.Path {
+		if err = e.Write(w, p.PathArity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Proof) Read(r io.Reader) error {
+	b, err := trie.ReadByte(r)
+	if err != nil {
+		return err
+	}
+	p.PathArity = trie.PathArity(b)
+
+	var encodedKey []byte
+	if encodedKey, err = trie.ReadBytes16(r); err != nil {
+		return err
+	}
+	if p.Key, err = trie.DecodeToUnpackedBytes(encodedKey, p.PathArity); err != nil {
+		return err
+	}
+	var size uint16
+	if err = trie.ReadUint16(r, &size); err != nil {
+		return err
+	}
+	p.Path = make([]*ProofElement, size)
+	for i := range p.Path {
+		p.Path[i] = &ProofElement{}
+		if err = p.Path[i].Read(r, p.PathArity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const (
+	hasTerminalValueFlag = 0x01
+	hasChildrenFlag      = 0x02
+)
+
+func (e *ProofElement) Write(w io.Writer, arity trie.PathArity) error {
+	encodedPathFragment, err := trie.EncodeUnpackedBytes(e.PathFragment, arity)
+	if err != nil {
+		return err
+	}
+	if err = trie.WriteBytes16(w, encodedPathFragment); err != nil {
+		return err
+	}
+	if err = trie.WriteUint16(w, uint16(e.ChildIndex)); err != nil {
+		return err
+	}
+	var smallFlags byte
+	if e.Terminal != nil {
+		smallFlags = hasTerminalValueFlag
+	}
+	// compress children flags 32 bytes (if any)
+	var flags [32]byte
+	for i := range e.Children {
+		flags[i/8] |= 0x1 << (i % 8)
+		smallFlags |= hasChildrenFlag
+	}
+	if err := trie.WriteByte(w, smallFlags); err != nil {
+		return err
+	}
+	// write terminal commitment if any
+	if smallFlags&hasTerminalValueFlag != 0 {
+		if err = trie.WriteBytes8(w, e.Terminal); err != nil {
+			return err
+		}
+	}
+	// write child commitments if any
+	if smallFlags&hasChildrenFlag != 0 {
+		if _, err = w.Write(flags[:]); err != nil {
+			return err
+		}
+		for i := 0; i < arity.VectorLength(); i++ {
+			child, ok := e.Children[uint8(i)]
+			if !ok {
+				continue
+			}
+			if len(child) != HashSize {
+				return fmt.Errorf("wrong data size. Expected %d, got %d", HashSize, len(child))
+			}
+			if _, err = w.Write(child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *ProofElement) Read(r io.Reader, arity trie.PathArity) error {
+	var err error
+	var encodedPathFragment []byte
+	if encodedPathFragment, err = trie.ReadBytes16(r); err != nil {
+		return err
+	}
+	if e.PathFragment, err = trie.DecodeToUnpackedBytes(encodedPathFragment, arity); err != nil {
+		return err
+	}
+	var idx uint16
+	if err := trie.ReadUint16(r, &idx); err != nil {
+		return err
+	}
+	e.ChildIndex = int(idx)
+	var smallFlags byte
+	if smallFlags, err = trie.ReadByte(r); err != nil {
+		return err
+	}
+	if smallFlags&hasTerminalValueFlag != 0 {
+		if e.Terminal, err = trie.ReadBytes8(r); err != nil {
+			return err
+		}
+	} else {
+		e.Terminal = nil
+	}
+	e.Children = make(map[byte][]byte)
+	if smallFlags&hasChildrenFlag != 0 {
+		var flags [32]byte
+		if _, err = r.Read(flags[:]); err != nil {
+			return err
+		}
+		for i := 0; i < arity.NumChildren(); i++ {
+			ib := uint8(i)
+			if flags[i/8]&(0x1<<(i%8)) != 0 {
+				e.Children[ib] = make([]byte, HashSize)
+				if _, err = r.Read(e.Children[ib]); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/models/trie_mimc1/readme.md
+++ b/models/trie_mimc1/readme.md
@@ -1,0 +1,95 @@
+# Package `trie_blake2b`
+
+Package contains implementation of commitment model for the `256+ trie` based on `MIMC` 32 byte hashing.
+
+## Structure of the proof
+
+The proof of inclusion or absence is the proof of inclusion of key/value pair (K,V) into the key/value store.
+If your key value store is used to only keep keys as leafs, the key/value pair will be (K,K).
+
+The proof is a sequence of hashes `H[0], ..., H[N-1]` where:
+* `H[N-1]` includes value V as part of it
+* `H[0]` is a root hash. It must be equal to the root hash value provided from outside by the verifier
+* must be `H[i]` = `Hash(H[i+1])` along the path
+
+The proof in the `trie-mimc.CommitmentModel` implementation is represented by two data structure
+
+```go
+type Proof struct {
+    PathArity trie.PathArity
+    Key       []byte
+    Path      []*ProofElement
+}
+```
+and
+```go
+type ProofElement struct {
+    PathFragment []byte
+    Children     map[byte][]byte
+    Terminal     []byte
+    ChildIndex   int
+}
+```
+
+The proof as a data has no dependencies to any data structures. The only functionality needed in order to check the validity of the proof
+is ability of MIMC-hashing of the binary representation of hashes.
+
+You will retrieve the proof by calling `proof := model.Proof(key, trie)` where `model` was created 
+with ` model := trie_mimc1.New(trie.PathArity2))` and the `trie := tr := trie.New(m, store, nil)`.
+
+This way it is guaranteed that the proof is correct. But to check it against specific root hash `root` 
+you call `trie_mimc1_verify.Validate(proof, root)`. 
+
+The `Proof` structure has header information:
+* `PathArity` will be `1` for binary tries
+* `Key` will be equal the key you want to check in the key/value store i.e. what you provided in the call `model.Proof(key, trie)` 
+
+The `Path` is a list of `ProofElement`'s. Each proof element in the list is used to compute the hash `H[i]` above.
+
+Let's say the `Path` contains `N` elements. 
+* Only the last element in the proof path at index `N-1` contains all information needed to compute `H[N-1]`:
+* each element at other index `i` will need to value of `H[i+1]` to compute `H[i]`
+* So, we start at last one at `H[N-1]` and then compute one by one up to the `H[0]`
+
+For binary tree, the last element `proof.Path[N-1]` will always contain:
+* value `V` corresponding to the key `K` in the key/value store as
+`proof.Path[N-1].Terminal`. It cannot be `nil` for proof of existence (if the (K,V) exists in the key/value store). 
+It will be MIMC hash of the raw commitment to data (which may by up to 33 byte long)
+* 0, 1 or 2 values in the map `proof.Path[N-1].Children`
+* `proof.Path[N-1].ChildIndex` is not important for the last element in the path
+
+The hash `H[N-1]` is computed by concatenating `proof.Path[N-1].Children[0], proof.Path[N-1].Children[1], proof.Path[N-1].Terminal, proof.Path[N-1].PathFragment` 
+If value is `nil` (it cannot be for terminal in the last element), the all-0 value `[32]byte{}` is used.
+
+So this was the last element in the path.
+Now we go to the next one at index `N-2`, and so on to `N-3` down to inde `0`.
+Each element `proof.Path[i].ChildIndex` where `i<N-1` will contain for binary tree:
+* exactly 1 element in the `proof.Path[i].Children` either at index `0` or index `1`. The missing (`nil`) element in the map `proof.Path[i].Children` 
+will be at index `proof.Path[i].ChildIndex`. It can be only `0` or `1` for the binary tree. That would be the hash from below (next proof element).
+The other will be the sibling hash already present int the tree. 
+
+So, for the `proof.Path[i]` the `H[i]` is calculated by concatenating and hashing the following values:
+`C0[i], C1[i], proof.Path[i].Terminal, proof.Path[i].PathFragment` (`nil` mean all-0).
+Here: 
+If `proof.Path[i].ChildIndex == 0` then:  
+* `C[0] = H[i+1]`
+* `C[1] = proof.Path[i].Children[1]`
+
+Otherwise, if `proof.Path[i].ChildIndex == 1` then:
+* `C[0] = proof.Path[i].Children[0]`
+* `C[1] = H[i+1]`
+
+(other than `0` or `1` value are not possible in the binary tree)
+
+The whole logic of forming the vector for hashing is in the functions `hashIt`, `makeHashVector` and `HashTheVector` 
+
+## Summery: how to generate circuit
+1. Have key K
+2. Call `proof := model.Proof(key, trie)`
+3. Call `trie_mimc1_verify.Validate(proof, root)`. It checks syntactic validity of the proof and is it the valid proof against you `root`. 
+4. The proof will prove the inclusion of key K with the value committed in the `Terminal` field in the last element in the `Path`.
+5. You generate circuit going from the last element in the path `proof.Path[N-1]` to the element `0`. 
+6. In each step you generate a circuit corresponding to 4 values (not 2): 1 sibling, 1 child, terminal, and the path fragment. 
+7. Terminal will be not `nil` in the last element, exactly 1 child will be in the elements which are not the last one
+8. Which one is child and which one is sibling is contained in the `ChildIndex` field which is `0` or `1`
+

--- a/models/trie_mimc1/trie_mimc1_verify/verify.go
+++ b/models/trie_mimc1/trie_mimc1_verify/verify.go
@@ -1,0 +1,141 @@
+package trie_mimc1_verify
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	trie_mimc "github.com/iotaledger/trie.go/models/trie_mimc1"
+	"github.com/iotaledger/trie.go/trie"
+	"golang.org/x/xerrors"
+)
+
+// MustKeyWithTerminal returns key and terminal commitment the proof is about. It returns:
+// - key
+// - commitment slice of HashSize bytes long. If it is nil, the proof is a proof of absence
+// It does not verify the proof, so this function should be used only after Validate()
+func MustKeyWithTerminal(p *trie_mimc.Proof) ([]byte, []byte) {
+	if len(p.Path) == 0 {
+		return nil, nil
+	}
+	lastElem := p.Path[len(p.Path)-1]
+	switch {
+	case p.PathArity.IsChildIndex(lastElem.ChildIndex):
+		if _, ok := lastElem.Children[byte(lastElem.ChildIndex)]; ok {
+			panic("nil child commitment expected for proof of absence")
+		}
+		return p.Key, nil
+	case lastElem.ChildIndex == p.PathArity.TerminalCommitmentIndex():
+		if lastElem.Terminal == nil {
+			return p.Key, nil
+		}
+		return p.Key, lastElem.Terminal
+	case lastElem.ChildIndex == p.PathArity.PathFragmentCommitmentIndex():
+		return p.Key, nil
+	}
+	panic("wrong lastElem.ChildIndex")
+}
+
+// IsProofOfAbsence checks if it is proof of absence. Proof that the trie commits to something else in the place
+// where it would commit to the key if it would be present
+func IsProofOfAbsence(p *trie_mimc.Proof) bool {
+	_, r := MustKeyWithTerminal(p)
+	return r == nil
+}
+
+// Validate check the proof against the provided root commitments
+func Validate(p *trie_mimc.Proof, rootBytes []byte) error {
+	if len(p.Path) == 0 {
+		if len(rootBytes) != 0 {
+			return xerrors.New("proof is empty")
+		}
+		return nil
+	}
+	c, err := verify(p, 0, 0)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(c, rootBytes) {
+		return xerrors.New("invalid proof: commitment not equal to the root")
+	}
+	return nil
+}
+
+// ValidateWithValue checks the proof and checks if the proof commits to the specific value
+func ValidateWithValue(p *trie_mimc.Proof, rootBytes []byte, value []byte) error {
+	if err := Validate(p, rootBytes); err != nil {
+		return err
+	}
+	_, r := MustKeyWithTerminal(p)
+	if len(r) == 0 {
+		return errors.New("key is not present in the state")
+	}
+	if !bytes.Equal(trie_mimc.HashData(trie_mimc.CommitToDataRaw(value)), r) {
+		return errors.New("key does not correspond to the given value")
+	}
+	return nil
+}
+
+func verify(p *trie_mimc.Proof, pathIdx, keyIdx int) ([]byte, error) {
+	trie.Assert(pathIdx < len(p.Path), "assertion: pathIdx < lenPlus1(p.Path)")
+	trie.Assert(keyIdx <= len(p.Key), "assertion: keyIdx <= lenPlus1(p.Key)")
+
+	elem := p.Path[pathIdx]
+	tail := p.Key[keyIdx:]
+	isPrefix := bytes.HasPrefix(tail, elem.PathFragment)
+	last := pathIdx == len(p.Path)-1
+	if !last && !isPrefix {
+		return nil, fmt.Errorf("wrong proof: proof path does not follow the key. Path position: %d, key position %d", pathIdx, keyIdx)
+	}
+	if !last {
+		trie.Assert(isPrefix, "assertion: isPrefix")
+		if !p.PathArity.IsChildIndex(elem.ChildIndex) {
+			return nil, fmt.Errorf("wrong proof: wrong child index. Path position: %d, key position %d", pathIdx, keyIdx)
+		}
+		if _, ok := elem.Children[byte(elem.ChildIndex)]; ok {
+			return nil, fmt.Errorf("wrong proof: unexpected commitment at child index %d. Path position: %d, key position %d", elem.ChildIndex, pathIdx, keyIdx)
+		}
+		nextKeyIdx := keyIdx + len(elem.PathFragment) + 1
+		if nextKeyIdx > len(p.Key) {
+			return nil, fmt.Errorf("wrong proof: proof path out of key bounds. Path position: %d, key position %d", pathIdx, keyIdx)
+		}
+		c, err := verify(p, pathIdx+1, nextKeyIdx)
+		if err != nil {
+			return nil, err
+		}
+		return hashIt(elem, c, p.PathArity), nil
+	}
+	// it is the last in the path
+	if p.PathArity.IsChildIndex(elem.ChildIndex) {
+		c := elem.Children[byte(elem.ChildIndex)]
+		if c != nil {
+			return nil, fmt.Errorf("wrong proof: child commitment of the last element expected to be nil. Path position: %d, key position %d", pathIdx, keyIdx)
+		}
+		return hashIt(elem, nil, p.PathArity), nil
+	}
+	if elem.ChildIndex != p.PathArity.TerminalCommitmentIndex() && elem.ChildIndex != p.PathArity.PathFragmentCommitmentIndex() {
+		return nil, fmt.Errorf("wrong proof: child index expected to be %d or %d. Path position: %d, key position %d",
+			p.PathArity.TerminalCommitmentIndex(), p.PathArity.PathFragmentCommitmentIndex(), pathIdx, keyIdx)
+	}
+	return hashIt(elem, nil, p.PathArity), nil
+}
+
+func makeHashVector(e *trie_mimc.ProofElement, missingCommitment []byte, arity trie.PathArity) [][]byte {
+	hashes := make([][]byte, arity.VectorLength())
+	for idx, c := range e.Children {
+		trie.Assert(arity.IsChildIndex(int(idx)), "arity.IsChildIndex(int(idx)")
+		hashes[idx] = c
+	}
+	if len(e.Terminal) > 0 {
+		hashes[arity.TerminalCommitmentIndex()] = e.Terminal
+	}
+	hashes[arity.PathFragmentCommitmentIndex()] = trie_mimc.HashData(e.PathFragment)
+	if arity.IsChildIndex(e.ChildIndex) {
+		hashes[e.ChildIndex] = missingCommitment
+	}
+	return hashes
+}
+
+func hashIt(e *trie_mimc.ProofElement, missingCommitment []byte, arity trie.PathArity) []byte {
+	return trie_mimc.HashTheVector(makeHashVector(e, missingCommitment, arity), arity)
+}


### PR DESCRIPTION
Implemented MIMC commitment model which uses 32-byte hashes everywhere