### PR TITLE
Equals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+kzg_setup
+mk_trie_mut
+trie_bench_mut
+trie_example_kzg_mut
+trie_example_mut

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+#
+# You can override these e.g. as
+#     make test TEST_PKG=./immutable/tests/ TEST_ARG="-v --run TestDeletedKey"
+#
+TEST_PKG=./...
+TEST_ARG=
+
+BUILD_PKGS=./...
+BUILD_CMD=go build -o .
+INSTALL_CMD=go install
+
+all: build-lint
+
+build:
+	$(BUILD_CMD) $(BUILD_PKGS)
+
+build-lint: build lint
+
+test: install
+	go test $(TEST_PKG) --timeout 10m --count 1 -failfast $(TEST_ARG)
+
+install:
+	$(INSTALL_CMD) $(BUILD_PKGS)
+
+lint:
+	golangci-lint run --timeout 5m
+
+.PHONY: all build build-lint test install lint

--- a/common/commitment.go
+++ b/common/commitment.go
@@ -19,6 +19,7 @@ type Serializable interface {
 // VCommitment represents interface to the vector commitment. It can be hash, or it can be a curve element
 type VCommitment interface {
 	Clone() VCommitment
+	Equals(VCommitment) bool
 	Serializable
 }
 

--- a/immutable/node.go
+++ b/immutable/node.go
@@ -60,7 +60,7 @@ func (n *bufferedNode) mustPersist(w common.KVWriter, m common.CommitmentModel) 
 	w.Set(dbKey, buf.Bytes())
 }
 
-func (n *bufferedNode) isCommitted(m common.CommitmentModel) bool {
+func (n *bufferedNode) isCommitted(m common.CommitmentModel) bool { // nolint:unused	// TODO: use function or delete it
 	if !m.EqualCommitments(n.terminal, n.nodeData.Terminal) {
 		return false
 	}

--- a/models/trie_blake2b/model.go
+++ b/models/trie_blake2b/model.go
@@ -294,6 +294,14 @@ func (v vectorCommitment) Clone() common.VCommitment {
 	return vectorCommitment(ret)
 }
 
+func (v vectorCommitment) Equals(other common.VCommitment) bool {
+	o, ok := other.(vectorCommitment)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(v, o)
+}
+
 func (v vectorCommitment) Update(delta common.VCommitment) {
 	m, ok := delta.(vectorCommitment)
 	if !ok {

--- a/models/trie_kzg_bn256/fun.go
+++ b/models/trie_kzg_bn256/fun.go
@@ -110,7 +110,7 @@ func (sd *TrustedSetup) verifyVector(vect []kyber.Scalar, c kyber.Point) bool {
 // commitAll return commit to the whole vector and to each of values of it
 // Generate commitment to the vector and proofs to all values.
 // Expensive. Usually used only in tests
-func (sd *TrustedSetup) commitAll(vect []kyber.Scalar) (kyber.Point, []kyber.Point) {
+func (sd *TrustedSetup) commitAll(vect []kyber.Scalar) (kyber.Point, []kyber.Point) { // nolint:unused	// TODO: use function or delete it
 	retC := sd.commit(vect)
 	retPi := make([]kyber.Point, sd.D)
 	for i := range vect {

--- a/models/trie_kzg_bn256/kzg_setup/kzg_setup.go
+++ b/models/trie_kzg_bn256/kzg_setup/kzg_setup.go
@@ -109,7 +109,7 @@ func writeToFile(tr *trie_kzg_bn2562.TrustedSetup, fname string) {
 			dataStr += " +\n"
 		}
 		res := strings.Replace(ftemplate, "{{HEX DATA}}", dataStr, 1)
-		_, err = fmt.Fprintf(f, res)
+		fmt.Fprint(f, res)
 	}
 }
 

--- a/models/trie_kzg_bn256/model.go
+++ b/models/trie_kzg_bn256/model.go
@@ -202,7 +202,8 @@ func (m *CommitmentModel) UpdateNodeCommitment(mutate *common.NodeData, childUpd
 				// child didn't exist, no need to delete it
 				continue
 			}
-			delta := m.TrustedSetup.Suite.G1().Scalar().Zero()
+			var delta kyber.Scalar
+			//delta := m.TrustedSetup.Suite.G1().Scalar().Zero() // TODO: the value is not used. Remove the line?
 			if childUpd == nil {
 				// deleting child
 				common.Assert(prevC != nil, "prevC != nil")

--- a/models/trie_kzg_bn256/model.go
+++ b/models/trie_kzg_bn256/model.go
@@ -58,6 +58,14 @@ func (v *vectorCommitment) Clone() common.VCommitment {
 	return &vectorCommitment{Point: v.Point.Clone()}
 }
 
+func (v *vectorCommitment) Equals(other common.VCommitment) bool {
+	o, ok := other.(*vectorCommitment)
+	if !ok {
+		return false
+	}
+	return v.Point.Equal(o.Point)
+}
+
 // *terminalCommitment implements trie_go.TCommitment
 var _ common.TCommitment = &terminalCommitment{}
 

--- a/mutable/trie.go
+++ b/mutable/trie.go
@@ -315,12 +315,9 @@ func (tr *Trie) hasCommitment(key []byte) bool {
 		}
 	}
 	// new commitments do not come from children
-	if len(n.n.ChildCommitments) > 0 {
-		// existing children commit
-		return true
-	}
-	// node does not commit to anything
-	return false
+	// if true - existing children commit
+	// if false - node does not commit to anything
+	return len(n.n.ChildCommitments) > 0
 }
 
 type reorgStatus int


### PR DESCRIPTION
Mainly `Equals` method in `VCommitment` objects.
Other changes:
* `Makefile` to ease building
* `.gitignore` for git to ignore some build products
* Changer required by linter